### PR TITLE
Add OSX install and use instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ ARCH
 pacman -S libcurl-gnutls && \
 npm install && \
 npm run start
+
+OSX
+brew install gnutls curl
+npm install && \ 
+npm run start
 ```
 
 ## Let's forge some requests?


### PR DESCRIPTION
Tested server startup on OSX on

`Darwin hax.local 21.5.0 Darwin Kernel Version 21.5.0: Tue Apr 26 21:08:22 PDT 2022; root:xnu-8020.121.3~4/RELEASE_X86_64 x86_64`

Signed-off-by: Nathan Dautenhahn <ndd@rice.edu>